### PR TITLE
fix: 减少AI输出中的多余空行

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -71,7 +71,10 @@ const RenderBlock: React.FC<{ block: MarkdownBlock; showCursor?: boolean }> = Re
         );
       }
 
-      const rendered = marked.parse(block.content, { async: false }) as string;
+      const rendered = (marked.parse(block.content, { async: false }) as string)
+        .replace(/\n{3,}/g, '\n\n')  // 合并连续空行（3+个换行→2个）
+        .replace(/^\n+/, '')          // 去除开头空行
+        .replace(/\n+$/, '');         // 去除结尾空行
       return (
         <Box marginBottom={block.type === 'paragraph' ? 0 : 1}>
           <Text>{rendered}</Text>

--- a/src/components/StreamingMessage.tsx
+++ b/src/components/StreamingMessage.tsx
@@ -97,7 +97,10 @@ const RenderBlock: React.FC<{ block: MarkdownBlock; showCursor?: boolean }> = Re
       }
 
       // 统一使用 marked 渲染（非表格）
-      const rendered = marked.parse(block.content, { async: false }) as string;
+      const rendered = (marked.parse(block.content, { async: false }) as string)
+        .replace(/\n{3,}/g, '\n\n')  // 合并连续空行（3+个换行→2个）
+        .replace(/^\n+/, '')          // 去除开头空行
+        .replace(/\n+$/, '');         // 去除结尾空行
 
       return (
         <Box marginBottom={block.type === 'paragraph' ? 0 : 1}>


### PR DESCRIPTION
## 修复内容

修复 #34 

AI 输出内容中 `marked-terminal` 渲染器会产生较多的空行，导致显示区域浪费。

## 修改方案

对 `marked.parse()` 的渲染结果进行后处理：

- **合并连续空行**：3个以上连续换行合并为2个换行（保留段落间距）
- **去除首尾空行**：移除渲染结果开头和结尾的多余换行

## 修改文件

- `src/components/StreamingMessage.tsx` — 流式输出渲染
- `src/components/Markdown.tsx` — 静态消息渲染

## 测试

- `npm run build` 编译通过